### PR TITLE
Fix GitHub Actions release workflow to upload correct build artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,14 +46,34 @@ jobs:
       - name: Build Tauri app
         run: npm run tauri build
 
+      - name: List build outputs
+        shell: bash
+        run: |
+          echo "=== Checking build outputs ==="
+          echo "Release directory:"
+          ls -la ./src-tauri/target/release/ || echo "Release directory not found"
+          echo ""
+          echo "Bundle directory:"
+          ls -la ./src-tauri/target/release/bundle/ || echo "Bundle directory not found"
+          echo ""
+          if [ -d "./src-tauri/target/release/bundle" ]; then
+            echo "Bundle subdirectories:"
+            find ./src-tauri/target/release/bundle -type d -maxdepth 2
+            echo ""
+            echo "All files in bundle:"
+            find ./src-tauri/target/release/bundle -type f | head -20
+          fi
+
       - name: Check if executable exists (Windows)
         if: matrix.os == 'windows-latest'
         run: |
-          if (-not (Test-Path "./src-tauri/target/release/bc.exe")) {
-            Write-Error "Build failed: bc.exe not found"
+          # Check for NSIS installer
+          $nsisInstaller = Get-ChildItem -Path "./src-tauri/target/release/bundle/nsis/" -Filter "*-setup.exe" -ErrorAction SilentlyContinue
+          if (-not $nsisInstaller) {
+            Write-Error "Build failed: NSIS installer not found"
             exit 1
           }
-          Write-Host "Build successful: bc.exe found"
+          Write-Host "Build successful: NSIS installer found at $($nsisInstaller.FullName)"
 
       - name: Check if executable exists (macOS)
         if: matrix.os == 'macos-latest'
@@ -69,7 +89,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: bc-windows
-          path: ./src-tauri/target/release/bc.exe
+          path: ./src-tauri/target/release/bundle/nsis/*-setup.exe
 
       - name: List macOS build outputs
         if: matrix.os == 'macos-latest'
@@ -99,6 +119,15 @@ jobs:
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
+        with:
+          path: ./artifacts
+
+      - name: List downloaded artifacts
+        run: |
+          echo "=== All downloaded artifacts ==="
+          find ./artifacts -type f -ls
+          echo "=== Directory structure ==="
+          ls -la ./artifacts/
 
       - name: Get PR body
         id: pr-body
@@ -135,56 +164,82 @@ jobs:
       - name: Rename artifacts
         run: |
           # Debug: List downloaded artifact structure
-          echo "=== Artifact structure ==="
+          echo "=== Working directory ==="
+          pwd
+          echo "=== Current directory contents ==="
           ls -la
+          echo "=== Artifacts directory contents ==="
+          ls -la ./artifacts/ || echo "artifacts directory not found"
           echo "=== bc-windows contents ==="
-          ls -la ./bc-windows/ || echo "bc-windows directory not found"
+          ls -la ./artifacts/bc-windows/ || echo "bc-windows directory not found"
           echo "=== bc-macos contents ==="
-          ls -la ./bc-macos/ || echo "bc-macos directory not found"
+          ls -la ./artifacts/bc-macos/ || echo "bc-macos directory not found"
           
           # Rename Windows artifact
-          if [ -f "./bc-windows/bc.exe" ]; then
-            mv ./bc-windows/bc.exe ./bc-v${{ steps.package-version.outputs.VERSION }}-windows-x64.exe
+          # Find the NSIS installer
+          WINDOWS_INSTALLER=$(find ./artifacts/bc-windows -name "*-setup.exe" -type f 2>/dev/null | head -1)
+          if [ -n "$WINDOWS_INSTALLER" ]; then
+            mv "$WINDOWS_INSTALLER" ./bc-v${{ steps.package-version.outputs.VERSION }}-windows-x64-setup.exe
+            echo "Windows installer renamed successfully from $WINDOWS_INSTALLER"
           else
-            echo "Error: Windows executable not found"
-            exit 1
+            echo "Error: Windows installer not found"
+            echo "Searching for setup.exe files..."
+            find ./artifacts -name "*-setup.exe" -type f 2>/dev/null || echo "No setup.exe files found"
+            # Also search for any exe files
+            echo "All exe files in artifacts:"
+            find ./artifacts -name "*.exe" -type f 2>/dev/null || echo "No exe files found"
           fi
           
           # Find and rename macOS DMG
-          # The DMG should be directly in bc-macos directory after download
-          DMG_FILE=$(find ./bc-macos -name "*.dmg" -type f 2>/dev/null | head -1)
+          DMG_FILE=$(find ./artifacts/bc-macos -name "*.dmg" -type f 2>/dev/null | head -1)
           if [ -n "$DMG_FILE" ]; then
             echo "Found DMG: $DMG_FILE"
             mv "$DMG_FILE" ./bc-v${{ steps.package-version.outputs.VERSION }}-macos.dmg
+            echo "macOS artifact renamed successfully"
           else
             echo "Warning: No DMG file found in bc-macos directory"
-            echo "Contents of bc-macos:"
-            find ./bc-macos -type f 2>/dev/null || echo "bc-macos directory is empty or doesn't exist"
+            echo "Searching for DMG files..."
+            find ./artifacts -name "*.dmg" -type f 2>/dev/null || echo "No DMG files found anywhere"
           fi
 
       - name: Prepare artifact list
         id: artifacts
         run: |
+          # List files in current directory to debug
+          echo "=== Files in current directory ==="
+          ls -la *.exe *.dmg 2>/dev/null || echo "No exe or dmg files in current directory"
+          
           # Build artifact list
           ARTIFACTS=""
           
           # Add Windows artifact if it exists
-          if [ -f "./bc-v${{ steps.package-version.outputs.VERSION }}-windows-x64.exe" ]; then
-            ARTIFACTS="./bc-v${{ steps.package-version.outputs.VERSION }}-windows-x64.exe"
+          WINDOWS_INSTALLER="./bc-v${{ steps.package-version.outputs.VERSION }}-windows-x64-setup.exe"
+          if [ -f "$WINDOWS_INSTALLER" ]; then
+            ARTIFACTS="$WINDOWS_INSTALLER"
+            echo "Found Windows artifact: $WINDOWS_INSTALLER"
+          else
+            echo "Warning: Windows artifact not found at $WINDOWS_INSTALLER"
           fi
           
           # Add macOS artifact if it exists
-          if [ -f "./bc-v${{ steps.package-version.outputs.VERSION }}-macos.dmg" ]; then
+          MACOS_DMG="./bc-v${{ steps.package-version.outputs.VERSION }}-macos.dmg"
+          if [ -f "$MACOS_DMG" ]; then
             if [ -n "$ARTIFACTS" ]; then
-              ARTIFACTS="$ARTIFACTS,./bc-v${{ steps.package-version.outputs.VERSION }}-macos.dmg"
+              ARTIFACTS="$ARTIFACTS,$MACOS_DMG"
             else
-              ARTIFACTS="./bc-v${{ steps.package-version.outputs.VERSION }}-macos.dmg"
+              ARTIFACTS="$MACOS_DMG"
             fi
+            echo "Found macOS artifact: $MACOS_DMG"
+          else
+            echo "Warning: macOS artifact not found at $MACOS_DMG"
           fi
           
           # Ensure we have at least one artifact
           if [ -z "$ARTIFACTS" ]; then
             echo "Error: No artifacts found to upload"
+            echo "Expected artifacts:"
+            echo "  - $WINDOWS_INSTALLER"
+            echo "  - $MACOS_DMG"
             exit 1
           fi
           
@@ -195,7 +250,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           artifacts: ${{ steps.artifacts.outputs.ARTIFACTS }}
-          artifactErrorsFailBuild: false
+          artifactErrorsFailBuild: true
           tag: v${{ steps.package-version.outputs.VERSION }}
           name: BC App v${{ steps.package-version.outputs.VERSION }}
           body: ${{ steps.pr-body.outputs.PR_BODY }}


### PR DESCRIPTION
- Changed to upload NSIS installer for Windows instead of raw executable
- Added proper artifact download path specification
- Fixed artifact renaming to handle installer files correctly
- Added extensive debugging output to track build artifacts
- Changed artifactErrorsFailBuild to true to fail on upload errors
- Updated file paths to match actual Tauri build output structure

The workflow was looking for bc.exe but Tauri builds create:
- Windows: NSIS installer at bundle/nsis/*-setup.exe
- macOS: DMG at bundle/dmg/*.dmg

🤖 Generated with [Claude Code](https://claude.ai/code)